### PR TITLE
Make OpenSimplexNoiseKS package private.

### DIFF
--- a/src/algorithms/noise/OpenSimplexNoiseKS.java
+++ b/src/algorithms/noise/OpenSimplexNoiseKS.java
@@ -15,7 +15,7 @@ package algorithms.noise;
  *   will be the same when ported to other languages.
  */
  
-public class OpenSimplexNoiseKS {
+class OpenSimplexNoiseKS {
 
   private static final double STRETCH_CONSTANT_2D = -0.211324865405187;    //(1/Math.sqrt(2+1)-1)/2;
   private static final double SQUISH_CONSTANT_2D = 0.366025403784439;      //(Math.sqrt(2+1)-1)/2;


### PR DESCRIPTION
Prevents library users from incorrectly using the `OpenSimplexNoiseKS` class instead of the preferred `OpenSimplexNoise` class.

Fixes #2 